### PR TITLE
[BIOMAGE-2103] - Fix workflow failures notification

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,17 +91,6 @@ jobs:
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v1
 
-    - id: send-to-slack
-      name: Send failure notification to Slack
-      if: failure() && github.event_name == 'push'
-      env:
-        SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
-      uses: voxmedia/github-action-slack-notify-build@v1
-      with:
-        channel: workflow-failures
-        status: FAILED
-        color: danger
-
   build-docker:
     name: Build Docker container
     runs-on: ubuntu-20.04
@@ -194,17 +183,6 @@ jobs:
           docker push $IMAGE_NAME
         env:
           IMAGE_NAME: ${{ format('{0}/{1}:{2}', steps.login-ecr.outputs.registry, steps.ref.outputs.repo-name, steps.ref.outputs.image-tag) }}
-
-      - id: send-to-slack
-        name: Send failure notification to Slack
-        if: failure() && github.event_name == 'push'
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: workflow-failures
-          status: FAILED
-          color: danger
 
   deploy:
     name: Deploy to Kubernetes
@@ -368,17 +346,6 @@ jobs:
           enforce_admins: true
           retries: 8
 
-      - id: send-to-slack
-        name: Send failure notification to Slack
-        if: failure() && github.event_name == 'push'
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
-        uses: voxmedia/github-action-slack-notify-build@v1
-        with:
-          channel: workflow-failures
-          status: FAILED
-          color: danger
-
   ready-to-merge:
     name: Ready for merging
     runs-on: ubuntu-20.04
@@ -388,3 +355,19 @@ jobs:
         name: Signal readiness to merge
         run: |-
           exit 0
+
+  report-if-failed:
+    name: Report if workflow failed
+    runs-on: ubuntu-20.04
+    needs: [test, build-docker, deploy]
+    if: failure() && github.ref == 'refs/heads/master'
+    steps:
+      - id: send-to-slack
+        name: Send failure notification to Slack on failure
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
+        uses: voxmedia/github-action-slack-notify-build@v1
+        with:
+          channel: workflow-failures
+          status: FAILED
+          color: danger

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,10 +95,10 @@ jobs:
       name: Send failure notification to Slack
       if: failure() && github.event_name == 'push'
       env:
-        SLACK_BOT_TOKEN: ${{ secrets.BUILD_STATUS_BOT_TOKEN }}
+        SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
       uses: voxmedia/github-action-slack-notify-build@v1
       with:
-        channel: pipelines
+        channel: workflow-failures
         status: FAILED
         color: danger
 
@@ -199,10 +199,10 @@ jobs:
         name: Send failure notification to Slack
         if: failure() && github.event_name == 'push'
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.BUILD_STATUS_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel: pipelines
+          channel: workflow-failures
           status: FAILED
           color: danger
 
@@ -372,10 +372,10 @@ jobs:
         name: Send failure notification to Slack
         if: failure() && github.event_name == 'push'
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.BUILD_STATUS_BOT_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.WORKFLOW_STATUS_BOT_TOKEN }}
         uses: voxmedia/github-action-slack-notify-build@v1
         with:
-          channel: pipelines
+          channel: workflow-failures
           status: FAILED
           color: danger
 


### PR DESCRIPTION
# Description
We are not notified of failing workflows anymore because we have not setup the bot token. This PR replaces the token with a new one. I've also inserted the bot token as a repository secret.

https://biomage.atlassian.net/browse/BIOMAGE-2103

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [x] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.