### PR TITLE
Set default `options` value to empty object

### DIFF
--- a/src/sql/migrations/20221013113149_add_sample_options.js
+++ b/src/sql/migrations/20221013113149_add_sample_options.js
@@ -54,7 +54,6 @@ const oldGenerateGem2sParamsHash = (experiment, samples) => {
 // Node14 has partial support for optional chaining operator (?.), I removed them for this migration
 const newGenerateGem2sParamsHash = (experiment, samples) => {
   if (!experiment || !samples || experiment.sampleIds.length === 0) {
-    console.log('*** invalid experiment skipped: ', experiment.id);
     return false;
   }
 
@@ -62,7 +61,6 @@ const newGenerateGem2sParamsHash = (experiment, samples) => {
   const orderInvariantSampleIds = [...experiment.sampleIds].sort();
 
   if (!(orderInvariantSampleIds.every((sampleId) => samples[sampleId]))) {
-    console.log('*** invalid experiment skipped: ', experiment.id);
     return false;
   }
 
@@ -169,21 +167,14 @@ const updateParamsHash = async (sqlClient, updates) => {
         pipeline_type: 'gem2s',
         experiment_id,
       });
-    console.log(`- Experiment ${experiment_id} successfully updated`);
   });
 
   return Promise.all(updatesPromise);
 };
 
 const migrateGem2sParamsHash = async (knex, isMigrateUp) => {
-  console.log('Getting experiments data...');
   const experiments = await getExperimentData(knex);
-  console.log('Finished getting experiments data...');
-  console.log(`Fetched ${experiments.length} experiments`);
-
-  console.log('Getting samples data...');
   const samples = await getSamplesData(knex);
-  console.log('Finished getting samples data...');
 
   const updateValues = Object.values(experiments).map((experiment) => ({
     experiment_id: experiment.id,
@@ -192,10 +183,7 @@ const migrateGem2sParamsHash = async (knex, isMigrateUp) => {
       : oldGenerateGem2sParamsHash(experiment, samples),
   })).filter(({ params_hash }) => params_hash !== false);
 
-  console.log(`Updating paramsHash of ${updateValues.length} experiments`);
-
   await updateParamsHash(knex, updateValues);
-  console.log(`${updateValues.length} experiments updated`);
 };
 
 /**

--- a/src/sql/migrations/20221028072756_default_options_to_empty_object.js
+++ b/src/sql/migrations/20221028072756_default_options_to_empty_object.js
@@ -1,3 +1,143 @@
+/* eslint-disable camelcase */
+// @ts-ignore
+const objectHash = require('object-hash');
+
+const METADATA_DEFAULT_VALUE = 'N.A';
+
+// Version from commit: https://github.com/biomage-org/ui/tree/844b3a6c4d9016dda938032cc20653c45ec0cf7b
+// Node14 has partial support for optional chaining operator (?.), I removed them for this migration
+const newGenerateGem2sParamsHash = (experiment, samples) => {
+  if (!experiment || !samples || experiment.sampleIds.length === 0) {
+    return false;
+  }
+
+  // Different sample order should not change the hash.
+  const orderInvariantSampleIds = [...experiment.sampleIds].sort();
+
+  if (!(orderInvariantSampleIds.every((sampleId) => samples[sampleId]))) {
+    return false;
+  }
+
+  const sampleTechnology = samples[orderInvariantSampleIds[0]].type;
+
+  const hashParams = {
+    organism: null,
+    sampleTechnology,
+    sampleIds: orderInvariantSampleIds,
+    sampleNames: orderInvariantSampleIds.map((sampleId) => samples[sampleId].name),
+    sampleOptions: orderInvariantSampleIds.map((sampleId) => samples[sampleId].options),
+  };
+
+  if (experiment.metadataKeys.length) {
+    const orderInvariantProjectMetadataKeys = [...experiment.metadataKeys].sort();
+
+    hashParams.metadata = orderInvariantProjectMetadataKeys.reduce((acc, key) => {
+      // Make sure the key does not contain '-' as it will cause failure in GEM2S
+      const sanitizedKey = key.replace(/-+/g, '_');
+
+      acc[sanitizedKey] = orderInvariantSampleIds.map(
+        (sampleId) => samples[sampleId].metadata[key] || METADATA_DEFAULT_VALUE,
+      );
+      return acc;
+    }, {});
+  }
+
+  const newHash = objectHash.sha1(
+    hashParams,
+    { unorderedObjects: true, unorderedArrays: true, unorderedSets: true },
+  );
+
+  return newHash;
+};
+
+const tables = {
+  EXPERIMENT: 'experiment',
+  EXPERIMENT_EXECUTION: 'experiment_execution',
+  METADATA_TRACK: 'metadata_track',
+  SAMPLE: 'sample',
+  METADATA_VALUE: 'sample_in_metadata_track_map',
+};
+
+const getExperimentData = async (sqlClient) => {
+  let experiments = await sqlClient.select(['id', 'samples_order']).from(tables.EXPERIMENT);
+  let metadataTracks = await sqlClient.select(['experiment_id', 'key']).from(tables.METADATA_TRACK);
+
+  metadataTracks = metadataTracks.reduce((acc, { experiment_id, key }) => {
+    if (!acc[experiment_id]) {
+      acc[experiment_id] = [];
+    }
+    acc[experiment_id].push(key);
+
+    return acc;
+  }, {});
+
+  // Transform experiments into a map so that it' easier to search
+  experiments = experiments.reduce((acc, curr) => {
+    acc[curr.id] = {
+      id: curr.id,
+      sampleIds: curr.samples_order || [],
+      metadataKeys: metadataTracks[curr.id] || [],
+    };
+
+    return acc;
+  }, {});
+
+  return experiments;
+};
+
+const getSamplesData = async (sqlClient) => {
+  let samples = await sqlClient.select(['id', 'name', 'sample_technology', 'options']).from(tables.SAMPLE);
+  let metadataValue = await sqlClient.select(['sample_id', 'key', 'value']).from(tables.METADATA_VALUE).innerJoin(tables.METADATA_TRACK, 'metadata_track_id', `${tables.METADATA_TRACK}.id`);
+
+  metadataValue = metadataValue.reduce((acc, curr) => {
+    acc[curr.sample_id] = {
+      ...acc[curr.sample_id],
+      [curr.key]: curr.value,
+    };
+
+    return acc;
+  }, {});
+
+  samples = samples.reduce((acc, curr) => {
+    acc[curr.id] = {
+      uuid: curr.id,
+      name: curr.name,
+      type: curr.sample_technology,
+      metadata: metadataValue[curr.id],
+      options: curr.options,
+    };
+
+    return acc;
+  }, {});
+
+  return samples;
+};
+
+const updateParamsHash = async (sqlClient, updates) => {
+  const updatesPromise = updates.map(async ({ experiment_id, params_hash }) => {
+    await sqlClient(tables.EXPERIMENT_EXECUTION)
+      .update({ params_hash })
+      .where({
+        pipeline_type: 'gem2s',
+        experiment_id,
+      });
+  });
+
+  return Promise.all(updatesPromise);
+};
+
+const migrateGem2sParamsHash = async (knex) => {
+  const experiments = await getExperimentData(knex);
+  const samples = await getSamplesData(knex);
+
+  const updateValues = Object.values(experiments).map((experiment) => ({
+    experiment_id: experiment.id,
+    params_hash: newGenerateGem2sParamsHash(experiment, samples),
+  })).filter(({ params_hash }) => params_hash !== false);
+
+  await updateParamsHash(knex, updateValues);
+};
+
 /**
  * @param { import("knex").Knex } knex
  * @returns { Promise<void> }
@@ -5,6 +145,9 @@
 exports.up = async (knex) => {
   // Update all null values to empty object
   await knex.table('sample').update({ options: '{}' }).where({ options: null });
+
+  // Recalculate gem2sParamsHash again
+  await migrateGem2sParamsHash(knex);
 
   await knex.schema.alterTable('sample', (table) => {
     table.jsonb('options').notNullable().defaultTo('{}').alter();

--- a/src/sql/migrations/20221028072756_default_options_to_empty_object.js
+++ b/src/sql/migrations/20221028072756_default_options_to_empty_object.js
@@ -1,0 +1,22 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async (knex) => {
+  // Update all null values to empty object
+  await knex.table('sample').update({ options: '{}' }).where({ options: null });
+
+  await knex.schema.alterTable('sample', (table) => {
+    table.jsonb('options').notNullable().defaultTo('{}').alter();
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async (knex) => {
+  await knex.schema.alterTable('sample', (table) => {
+    table.jsonb('options').nullable().alter();
+  });
+};


### PR DESCRIPTION
# Description
The default `null` value of the `options` column is causing failures when users add/replace samples to an existing experiment with samples.

https://this-is-biomage.slack.com/archives/C0250TDU1PF/p1666943992494889

# Details
#### URL to issue
N/A

#### Link to staging deployment URL (or set N/A)
N/A

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Code updates
Have best practices and ongoing refactors being observed in this PR
- [ ] Migrated any selector / reducer used to the new format.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.