### PR TITLE
[BIOMAGE-2407] - Allow track name to use space

### DIFF
--- a/src/api.v2/controllers/metadataTrackController.js
+++ b/src/api.v2/controllers/metadataTrackController.js
@@ -115,9 +115,9 @@ const parseMetadataFromTSV = (data, sampleNameToId) => {
   });
 
   const errors = [];
-  if (invalidSamples.size > 0) errors.push(`Invalid sample names: ${Array.from(invalidSamples).join(', ')}`);
-  if (invalidLines.length > 0) errors.push(`Invalid lines: ${invalidLines.join(', ')}`);
-  if (invalidDuplicates.length > 0) errors.push(`Multiple assignment on lines: ${invalidDuplicates.join(', ')}`);
+  if (invalidSamples.size > 0) errors.push(`Invalid sample names on line(s): ${Array.from(invalidSamples).join(', ')}`);
+  if (invalidLines.length > 0) errors.push(`Invalid line(s): ${invalidLines.join(', ')}`);
+  if (invalidDuplicates.length > 0) errors.push(`Multiple metadata assignment(s) on line(s): ${invalidDuplicates.join(', ')}`);
   if (errors.length > 0) throw new BadRequestError(errors.join('\n'));
 
   return result;

--- a/src/api.v2/controllers/metadataTrackController.js
+++ b/src/api.v2/controllers/metadataTrackController.js
@@ -102,13 +102,12 @@ const parseMetadataFromTSV = (data, sampleNameToId) => {
       invalidSamples.add(sampleName);
     }
 
-    // Check for duplicates
+    // Check for multiple metadata assignment to the same sample and track
     if (sampleMetadataPair[`${sampleName}@${metadataKey}`] === undefined) {
-      sampleMetadataPair[`${sampleName}@${metadataKey}`] = index;
+      sampleMetadataPair[`${sampleName}@${metadataKey}`] = index + 1;
     } else {
-      // Show metadata track with unreplaced value
       const duplicateLine = sampleMetadataPair[`${sampleName}@${metadataKey}`];
-      invalidDuplicates.push(`${duplicateLine} & ${index}`);
+      invalidDuplicates.push(`${duplicateLine} & ${index + 1}`);
     }
 
     return { sampleId: sampleNameToId[sampleName], metadataKey, metadataValue };

--- a/src/api.v2/controllers/metadataTrackController.js
+++ b/src/api.v2/controllers/metadataTrackController.js
@@ -84,7 +84,7 @@ const parseMetadataFromTSV = (data, sampleNameToId) => {
   const invalidSamples = new Set();
   const invalidDuplicates = [];
 
-  const sampleMetadataPair = {};
+  const sampleMetadataPairCounts = {};
 
   const result = data.trim().split('\n').map((line, index) => {
     // check that there are 3 elements per line
@@ -103,10 +103,10 @@ const parseMetadataFromTSV = (data, sampleNameToId) => {
     }
 
     // Check for multiple metadata assignment to the same sample and track
-    if (!Object.prototype.hasOwnProperty.call(sampleMetadataPair, `${sampleName}@${metadataKey}`)) {
-      sampleMetadataPair[`${sampleName}@${metadataKey}`] = index + 1;
+    if (!Object.prototype.hasOwnProperty.call(sampleMetadataPairCounts, `${sampleName}@${metadataKey}`)) {
+      sampleMetadataPairCounts[`${sampleName}@${metadataKey}`] = index + 1;
     } else {
-      const duplicateLine = sampleMetadataPair[`${sampleName}@${metadataKey}`];
+      const duplicateLine = sampleMetadataPairCounts[`${sampleName}@${metadataKey}`];
       invalidDuplicates.push(`${duplicateLine} & ${index + 1}`);
     }
 

--- a/src/api.v2/controllers/metadataTrackController.js
+++ b/src/api.v2/controllers/metadataTrackController.js
@@ -139,4 +139,5 @@ module.exports = {
   deleteMetadataTrack,
   patchValueForSample,
   createMetadataFromFile,
+  parseMetadataFromTSV,
 };

--- a/src/api.v2/controllers/metadataTrackController.js
+++ b/src/api.v2/controllers/metadataTrackController.js
@@ -85,13 +85,16 @@ const parseMetadataFromTSV = (data, sampleNameToId) => {
 
   const result = data.trim().split('\n').map((line, index) => {
     // check that there are 3 elements per line
-    const elements = line.split('\t');
+    const elements = line.trim().split('\t');
     if (elements.length !== 3) {
       invalidLines.push(index + 1);
     }
 
     // check that the sample name exists in the experiment
-    const [sampleName, metadataKey, metadataValue] = elements;
+    const sampleName = elements[0];
+    const metadataKey = elements[1].replace(/\s+/, '_');
+    const metadataValue = elements[2];
+
     if (!(sampleName in sampleNameToId)) {
       invalidSamples.add(sampleName);
     }

--- a/src/api.v2/controllers/metadataTrackController.js
+++ b/src/api.v2/controllers/metadataTrackController.js
@@ -93,9 +93,9 @@ const parseMetadataFromTSV = (data, sampleNameToId) => {
       invalidLines.push(index + 1);
     }
 
-    const sampleName = elements[0];
-    const metadataKey = elements[1].replace(/\s+/, '_');
-    const metadataValue = elements[2];
+    const sampleName = elements[0].trim();
+    const metadataKey = elements[1].trim().replace(/\s+/, '_');
+    const metadataValue = elements[2].trim();
 
     // check that the sample name exists in the experiment
     if (!(sampleName in sampleNameToId)) {
@@ -103,7 +103,7 @@ const parseMetadataFromTSV = (data, sampleNameToId) => {
     }
 
     // Check for multiple metadata assignment to the same sample and track
-    if (sampleMetadataPair[`${sampleName}@${metadataKey}`] === undefined) {
+    if (!Object.prototype.hasOwnProperty.call(sampleMetadataPair, `${sampleName}@${metadataKey}`)) {
       sampleMetadataPair[`${sampleName}@${metadataKey}`] = index + 1;
     } else {
       const duplicateLine = sampleMetadataPair[`${sampleName}@${metadataKey}`];

--- a/src/api.v2/controllers/metadataTrackController.js
+++ b/src/api.v2/controllers/metadataTrackController.js
@@ -117,7 +117,7 @@ const parseMetadataFromTSV = (data, sampleNameToId) => {
   const errors = [];
   if (invalidSamples.size > 0) errors.push(`Invalid sample names on line(s): ${Array.from(invalidSamples).join(', ')}`);
   if (invalidLines.length > 0) errors.push(`Invalid line(s): ${invalidLines.join(', ')}`);
-  if (invalidDuplicates.length > 0) errors.push(`Multiple metadata assignment(s) on line(s): ${invalidDuplicates.join(', ')}`);
+  if (invalidDuplicates.length > 0) errors.push(`Multiple assignment(s) to the same entry on line(s): ${invalidDuplicates.join(', ')}`);
   if (errors.length > 0) throw new BadRequestError(errors.join('\n'));
 
   return result;

--- a/src/api.v2/controllers/metadataTrackController.js
+++ b/src/api.v2/controllers/metadataTrackController.js
@@ -116,7 +116,7 @@ const parseMetadataFromTSV = (data, sampleNameToId) => {
   const errors = [];
   if (invalidSamples.size > 0) errors.push(`Invalid sample names on line(s): ${Array.from(invalidSamples).join(', ')}`);
   if (invalidLines.length > 0) errors.push(`Invalid line(s): ${invalidLines.join(', ')}`);
-  if (invalidDuplicates.length > 0) errors.push(`Multiple assignment(s) to the same entry on line(s): ${invalidDuplicates.join(', ')}`);
+  if (invalidDuplicates.length > 0) errors.push(`Multiple assignments to the same entry on lines: ${invalidDuplicates.join(', ')}`);
   if (errors.length > 0) throw new BadRequestError(errors.join('\n'));
 
   return result;

--- a/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
+++ b/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
@@ -70,7 +70,7 @@ Array [
 ]
 `;
 
-exports[`metadataTrackController parseMetadataFromTSV throws error if there are duplicated input 1`] = `"Multiple assignment(s) to the same entry on line(s): 1 & 2, 4 & 5"`;
+exports[`metadataTrackController parseMetadataFromTSV throws error if there are duplicated input 1`] = `"Multiple assignment(s) to the same entry on line(s): 2 & 3, 5 & 6"`;
 
 exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid lines 1`] = `"Invalid line(s): 1, 4, 5"`;
 

--- a/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
+++ b/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
@@ -18,17 +18,17 @@ Array [
     "sampleId": "mockSample3",
   },
   Object {
-    "metadataKey": "track_1",
+    "metadataKey": "track_2",
     "metadataValue": "value 1",
     "sampleId": "mockSample1",
   },
   Object {
-    "metadataKey": "track_1",
+    "metadataKey": "track_2",
     "metadataValue": "value 2",
     "sampleId": "mockSample2",
   },
   Object {
-    "metadataKey": "track_1",
+    "metadataKey": "track_2",
     "metadataValue": "value 3",
     "sampleId": "mockSample3",
   },
@@ -69,6 +69,8 @@ Array [
   },
 ]
 `;
+
+exports[`metadataTrackController parseMetadataFromTSV throws error if there are duplicated input 1`] = `"Multiple assignment on lines: 1 & 2, 4 & 5"`;
 
 exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid lines 1`] = `"Invalid lines: 1, 4, 5"`;
 

--- a/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
+++ b/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
@@ -70,7 +70,7 @@ Array [
 ]
 `;
 
-exports[`metadataTrackController parseMetadataFromTSV throws error if there are duplicated input 1`] = `"Multiple metadata assignment(s) on line(s): 1 & 2, 4 & 5"`;
+exports[`metadataTrackController parseMetadataFromTSV throws error if there are duplicated input 1`] = `"Multiple assignment(s) to the same entry on line(s): 1 & 2, 4 & 5"`;
 
 exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid lines 1`] = `"Invalid line(s): 1, 4, 5"`;
 

--- a/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
+++ b/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
@@ -70,11 +70,11 @@ Array [
 ]
 `;
 
-exports[`metadataTrackController parseMetadataFromTSV throws error if there are duplicated input 1`] = `"Multiple assignment on lines: 1 & 2, 4 & 5"`;
+exports[`metadataTrackController parseMetadataFromTSV throws error if there are duplicated input 1`] = `"Multiple metadata assignment(s) on line(s): 1 & 2, 4 & 5"`;
 
-exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid lines 1`] = `"Invalid lines: 1, 4, 5"`;
+exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid lines 1`] = `"Invalid line(s): 1, 4, 5"`;
 
-exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid samples 1`] = `"Invalid sample names: sample A, sample C"`;
+exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid samples 1`] = `"Invalid sample names on line(s): sample A, sample C"`;
 
 exports[`metadataTrackController parseMetadataFromTSV tolerates spaces after a line 1`] = `
 Array [

--- a/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
+++ b/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
@@ -70,7 +70,7 @@ Array [
 ]
 `;
 
-exports[`metadataTrackController parseMetadataFromTSV throws error if there are duplicated input 1`] = `"Multiple assignment(s) to the same entry on line(s): 2 & 3, 5 & 6"`;
+exports[`metadataTrackController parseMetadataFromTSV throws error if there are duplicated input 1`] = `"Multiple assignments to the same entry on lines: 2 & 3, 5 & 6"`;
 
 exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid lines 1`] = `"Cannot read property 'trim' of undefined"`;
 

--- a/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
+++ b/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
@@ -72,7 +72,7 @@ Array [
 
 exports[`metadataTrackController parseMetadataFromTSV throws error if there are duplicated input 1`] = `"Multiple assignment(s) to the same entry on line(s): 2 & 3, 5 & 6"`;
 
-exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid lines 1`] = `"Invalid line(s): 1, 4, 5"`;
+exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid lines 1`] = `"Cannot read property 'trim' of undefined"`;
 
 exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid samples 1`] = `"Invalid sample names on line(s): sample A, sample C"`;
 

--- a/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
+++ b/tests/api.v2/controllers/__snapshots__/metadataTrackController.test.js.snap
@@ -1,0 +1,110 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`metadataTrackController parseMetadataFromTSV can parse metadata tracks with spaces 1`] = `
+Array [
+  Object {
+    "metadataKey": "track_1",
+    "metadataValue": "value 1",
+    "sampleId": "mockSample1",
+  },
+  Object {
+    "metadataKey": "track_1",
+    "metadataValue": "value 2",
+    "sampleId": "mockSample2",
+  },
+  Object {
+    "metadataKey": "track_1",
+    "metadataValue": "value 3",
+    "sampleId": "mockSample3",
+  },
+  Object {
+    "metadataKey": "track_1",
+    "metadataValue": "value 1",
+    "sampleId": "mockSample1",
+  },
+  Object {
+    "metadataKey": "track_1",
+    "metadataValue": "value 2",
+    "sampleId": "mockSample2",
+  },
+  Object {
+    "metadataKey": "track_1",
+    "metadataValue": "value 3",
+    "sampleId": "mockSample3",
+  },
+]
+`;
+
+exports[`metadataTrackController parseMetadataFromTSV parses correctly 1`] = `
+Array [
+  Object {
+    "metadataKey": "track_1",
+    "metadataValue": "value 1",
+    "sampleId": "mockSample1",
+  },
+  Object {
+    "metadataKey": "track_1",
+    "metadataValue": "value 2",
+    "sampleId": "mockSample2",
+  },
+  Object {
+    "metadataKey": "track_1",
+    "metadataValue": "value 3",
+    "sampleId": "mockSample3",
+  },
+  Object {
+    "metadataKey": "track_2",
+    "metadataValue": "value 1",
+    "sampleId": "mockSample1",
+  },
+  Object {
+    "metadataKey": "track_2",
+    "metadataValue": "value 2",
+    "sampleId": "mockSample2",
+  },
+  Object {
+    "metadataKey": "track_2",
+    "metadataValue": "value 3",
+    "sampleId": "mockSample3",
+  },
+]
+`;
+
+exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid lines 1`] = `"Invalid lines: 1, 4, 5"`;
+
+exports[`metadataTrackController parseMetadataFromTSV throws error if there are invalid samples 1`] = `"Invalid sample names: sample A, sample C"`;
+
+exports[`metadataTrackController parseMetadataFromTSV tolerates spaces after a line 1`] = `
+Array [
+  Object {
+    "metadataKey": "track_1",
+    "metadataValue": "value 1",
+    "sampleId": "mockSample1",
+  },
+  Object {
+    "metadataKey": "track_1",
+    "metadataValue": "value 2",
+    "sampleId": "mockSample2",
+  },
+  Object {
+    "metadataKey": "track_1",
+    "metadataValue": "value 3",
+    "sampleId": "mockSample3",
+  },
+  Object {
+    "metadataKey": "track_2",
+    "metadataValue": "value 1",
+    "sampleId": "mockSample1",
+  },
+  Object {
+    "metadataKey": "track_2",
+    "metadataValue": "value 2",
+    "sampleId": "mockSample2",
+  },
+  Object {
+    "metadataKey": "track_2",
+    "metadataValue": "value 3",
+    "sampleId": "mockSample3",
+  },
+]
+`;

--- a/tests/api.v2/controllers/metadataTrackController.test.js
+++ b/tests/api.v2/controllers/metadataTrackController.test.js
@@ -246,6 +246,14 @@ describe('metadataTrackController', () => {
     }).toThrowErrorMatchingSnapshot();
   });
 
+  it('parseMetadataFromTSV throws error if there are duplicated input', () => {
+    const mockData = fs.readFileSync(path.join(__dirname, '../mocks/data/metadataInvalidDuplicates.tsv'), { encoding: 'utf-8' });
+
+    expect(() => {
+      metadataTrackController.parseMetadataFromTSV(mockData, mockMetadataSampleNameToId);
+    }).toThrowErrorMatchingSnapshot();
+  });
+
   it('parseMetadataFromTSV tolerates spaces after a line', () => {
     const mockData = fs.readFileSync(path.join(__dirname, '../mocks/data/metadataWithTrackSpaces.tsv'), { encoding: 'utf-8' });
     const result = metadataTrackController.parseMetadataFromTSV(

--- a/tests/api.v2/controllers/metadataTrackController.test.js
+++ b/tests/api.v2/controllers/metadataTrackController.test.js
@@ -1,12 +1,19 @@
 // @ts-nocheck
+const fs = require('fs');
+const path = require('path');
 const metadataTrackController = require('../../../src/api.v2/controllers/metadataTrackController');
 const { OK, NotFoundError, BadRequestError } = require('../../../src/utils/responses');
 const MetadataTrack = require('../../../src/api.v2/model/MetadataTrack');
 const Sample = require('../../../src/api.v2/model/Sample');
-const BasicModel = require('../../../src/api.v2/model/BasicModel');
 
 const metadataTrackInstance = new MetadataTrack();
 const sampleInstance = new Sample();
+
+const mockMetadataSampleNameToId = {
+  'sample 1': 'mockSample1',
+  'sample 2': 'mockSample2',
+  'sample 3': 'mockSample3',
+};
 
 jest.mock('../../../src/api.v2/model/MetadataTrack');
 jest.mock('../../../src/api.v2/model/Sample');
@@ -213,5 +220,45 @@ describe('metadataTrackController', () => {
     await expect(
       metadataTrackController.createMetadataFromFile(mockReq, mockRes),
     ).rejects.toThrowError(BadRequestError);
+  });
+
+  it('parseMetadataFromTSV parses correctly', () => {
+    const mockData = fs.readFileSync(path.join(__dirname, '../mocks/data/metadata.tsv'), { encoding: 'utf-8' });
+    const result = metadataTrackController.parseMetadataFromTSV(
+      mockData, mockMetadataSampleNameToId,
+    );
+    expect(result).toMatchSnapshot();
+  });
+
+  it('parseMetadataFromTSV throws error if there are invalid samples', () => {
+    const mockData = fs.readFileSync(path.join(__dirname, '../mocks/data/metadataInvalidSamples.tsv'), { encoding: 'utf-8' });
+
+    expect(() => {
+      metadataTrackController.parseMetadataFromTSV(mockData, mockMetadataSampleNameToId);
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it('parseMetadataFromTSV throws error if there are invalid lines', () => {
+    const mockData = fs.readFileSync(path.join(__dirname, '../mocks/data/metadataInvalidLines.tsv'), { encoding: 'utf-8' });
+
+    expect(() => {
+      metadataTrackController.parseMetadataFromTSV(mockData, mockMetadataSampleNameToId);
+    }).toThrowErrorMatchingSnapshot();
+  });
+
+  it('parseMetadataFromTSV tolerates spaces after a line', () => {
+    const mockData = fs.readFileSync(path.join(__dirname, '../mocks/data/metadataWithTrackSpaces.tsv'), { encoding: 'utf-8' });
+    const result = metadataTrackController.parseMetadataFromTSV(
+      mockData, mockMetadataSampleNameToId,
+    );
+    expect(result).toMatchSnapshot();
+  });
+
+  it('parseMetadataFromTSV can parse metadata tracks with spaces', () => {
+    const mockData = fs.readFileSync(path.join(__dirname, '../mocks/data/metadataWithLineSpaces.tsv'), { encoding: 'utf-8' });
+    const result = metadataTrackController.parseMetadataFromTSV(
+      mockData, mockMetadataSampleNameToId,
+    );
+    expect(result).toMatchSnapshot();
   });
 });

--- a/tests/api.v2/mocks/data/metadata.tsv
+++ b/tests/api.v2/mocks/data/metadata.tsv
@@ -1,0 +1,8 @@
+
+
+sample 1	track_1	value 1
+sample 2	track_1	value 2
+sample 3	track_1	value 3
+sample 1	track_2	value 1
+sample 2	track_2	value 2
+sample 3	track_2	value 3

--- a/tests/api.v2/mocks/data/metadataInvalidDuplicates.tsv
+++ b/tests/api.v2/mocks/data/metadataInvalidDuplicates.tsv
@@ -1,0 +1,10 @@
+
+
+sample 1	track_1	value 1
+sample 2	track_1	value 2
+sample 2	track_1	value 3
+sample 3	track_1	value 3
+sample 1	track_2	value 1
+sample 1	track_2	value 4
+sample 2	track_2	value 2
+sample 3	track_2	value 3

--- a/tests/api.v2/mocks/data/metadataInvalidLines.tsv
+++ b/tests/api.v2/mocks/data/metadataInvalidLines.tsv
@@ -1,0 +1,8 @@
+
+
+sample 1	track_1
+sample 2	track_1	value 2
+sample 3	track_1	value 3
+sample 1	track_2
+sample 2	track_2
+sample 3	track_2	value 3

--- a/tests/api.v2/mocks/data/metadataInvalidSamples.tsv
+++ b/tests/api.v2/mocks/data/metadataInvalidSamples.tsv
@@ -1,0 +1,8 @@
+
+
+sample A	track_1	value 1
+sample 2	track_1	value 2
+sample C	track_1	value 3
+sample A	track_2	value 1
+sample 2	track_2	value 2
+sample 3	track_2	value 3

--- a/tests/api.v2/mocks/data/metadataWithLineSpaces.tsv
+++ b/tests/api.v2/mocks/data/metadataWithLineSpaces.tsv
@@ -3,6 +3,6 @@
 sample 1	track_1	value 1    
 sample 2	track_1	value 2		 
 sample 3	track_1	value 3 	
-	sample 1	track_1	value 1
-   sample 2	track_1	value 2
- sample 3	track_1	value 3
+	sample 1	track_2	value 1
+   sample 2	track_2	value 2
+ sample 3	track_2	value 3

--- a/tests/api.v2/mocks/data/metadataWithLineSpaces.tsv
+++ b/tests/api.v2/mocks/data/metadataWithLineSpaces.tsv
@@ -1,0 +1,8 @@
+
+
+sample 1	track_1	value 1    
+sample 2	track_1	value 2		 
+sample 3	track_1	value 3 	
+	sample 1	track_1	value 1
+   sample 2	track_1	value 2
+ sample 3	track_1	value 3

--- a/tests/api.v2/mocks/data/metadataWithTrackSpaces.tsv
+++ b/tests/api.v2/mocks/data/metadataWithTrackSpaces.tsv
@@ -1,0 +1,8 @@
+
+
+sample 1	track 1	value 1
+sample 2	track 1	value 2
+sample 3	track 1	value 3
+sample 1	track 2	value 1
+sample 2	track 2	value 2
+sample 3	track 2	value 3


### PR DESCRIPTION
# Description
- Allow upload of files with metadata track names containing spaces
- Trim spaces at the end of lines, so unintended and invisible spaces doesn't cause an error

# Details
#### URL to issue
https://biomage.atlassian.net/browse/BIOMAGE-2407

#### Link to staging deployment URL (or set N/A)
N/A https://ui-agi-api117.scp-staging.biomage.net/

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Manual/unit testing
- [x] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.