### PR TITLE
[BIOMAGE-2346] - Remove `params_hash` column

### DIFF
--- a/src/api.v2/model/Experiment.js
+++ b/src/api.v2/model/Experiment.js
@@ -106,7 +106,7 @@ class Experiment extends BasicModel {
     }
 
     const experimentExecutionFields = [
-      'params_hash', 'state_machine_arn', 'execution_arn', 'last_gem2s_params',
+      'state_machine_arn', 'execution_arn', 'last_gem2s_params',
     ];
 
     const pipelineExecutionKeys = experimentExecutionFields.reduce((acum, current) => {

--- a/src/api.v2/model/ExperimentExecution.js
+++ b/src/api.v2/model/ExperimentExecution.js
@@ -5,7 +5,7 @@ const tableNames = require('./tableNames');
 
 const selectableProps = [
   'experiment_id', 'pipeline_type', 'state_machine_arn', 'execution_arn',
-  'last_status_response', 'last_gem2s_params', 'params_hash',
+  'last_status_response', 'last_gem2s_params',
 ];
 
 class ExperimentExecution extends BasicModel {

--- a/src/sql/migrations/20230303140501_delete_params_hash_field.js
+++ b/src/sql/migrations/20230303140501_delete_params_hash_field.js
@@ -1,0 +1,19 @@
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.up = async function (knex) {
+  await knex.schema.alterTable('experiment_execution', (table) => {
+    table.dropColumn('params_hash');
+  });
+};
+
+/**
+ * @param { import("knex").Knex } knex
+ * @returns { Promise<void> }
+ */
+exports.down = async function (knex) {
+  await knex.schema.alterTable('experiment_execution', (table) => {
+    table.string('params_hash').nullable();
+  });
+};

--- a/tests/api.v2/model/Experiment.test.js
+++ b/tests/api.v2/model/Experiment.test.js
@@ -22,7 +22,7 @@ jest.mock('../../../src/sql/helpers', () => ({
   collapseKeysIntoObject: jest.fn(),
   collapseKeyIntoArray: jest.fn(),
   replaceNullsWithObject: () => (`COALESCE(
-      jsonb_object_agg(pipeline_type, jsonb_build_object('params_hash', params_hash, 'state_machine_arn', state_machine_arn, 'execution_arn', execution_arn))
+      jsonb_object_agg(pipeline_type, jsonb_build_object('state_machine_arn', state_machine_arn, 'execution_arn', execution_arn))
       FILTER(
         WHERE pipeline_type IS NOT NULL
       ),

--- a/tests/api.v2/model/__snapshots__/Experiment.test.js.snap
+++ b/tests/api.v2/model/__snapshots__/Experiment.test.js.snap
@@ -25,7 +25,7 @@ Array [
 exports[`model/Experiment getExperimentData works correctly 1`] = `
 Array [
   "COALESCE(
-      jsonb_object_agg(pipeline_type, jsonb_build_object('params_hash', params_hash, 'state_machine_arn', state_machine_arn, 'execution_arn', execution_arn))
+      jsonb_object_agg(pipeline_type, jsonb_build_object('state_machine_arn', state_machine_arn, 'execution_arn', execution_arn))
       FILTER(
         WHERE pipeline_type IS NOT NULL
       ),

--- a/tests/utils/parseSNSMessage.test.js
+++ b/tests/utils/parseSNSMessage.test.js
@@ -35,7 +35,7 @@ describe('parseSNSMessage', () => {
     const mockReq = {
       params: { experimentId },
       headers: { authorization: 'mockAuthorization', 'x-amz-sns-topic-arn': receivedTopicArn },
-      body: JSON.stringify({ paramsHash: 'mockParamsHash' }),
+
     };
 
     await expect(parseSNSMessage(mockReq, expectedTopicArn)).rejects.toThrow(new Error('SNS topic doesn\'t match'));
@@ -45,17 +45,17 @@ describe('parseSNSMessage', () => {
     const mockReq = {
       params: { experimentId },
       headers: { authorization: 'mockAuthorization', 'x-amz-sns-topic-arn': expectedTopicArn },
-      body: '{ paramsHash: /invalid/ }',
+      body: '{ invalid: /body/ }',
     };
 
-    await expect(parseSNSMessage(mockReq, expectedTopicArn)).rejects.toThrow(new Error('Unexpected token p in JSON at position 2'));
+    await expect(parseSNSMessage(mockReq, expectedTopicArn)).rejects.toThrow(new Error('Unexpected token i in JSON at position 2'));
   });
 
   it('Fails if request body parsing doesnt work', async () => {
     const mockReq = {
       params: { experimentId },
       headers: { authorization: 'mockAuthorization', 'x-amz-sns-topic-arn': expectedTopicArn },
-      body: JSON.stringify({ paramsHash: 'mockParamsHash' }),
+      body: JSON.stringify({}),
     };
 
     mockValidate.mockImplementation(() => { throw new Error('Validation error'); });
@@ -67,7 +67,7 @@ describe('parseSNSMessage', () => {
     const mockReq = {
       params: { experimentId },
       headers: { authorization: 'mockAuthorization', 'x-amz-sns-topic-arn': expectedTopicArn },
-      body: JSON.stringify({ paramsHash: 'mockParamsHash' }),
+      body: JSON.stringify({}),
     };
 
     const mockMsg = 'mockMsg';
@@ -87,7 +87,7 @@ describe('parseSNSMessage', () => {
     const mockReq = {
       params: { experimentId },
       headers: { authorization: 'mockAuthorization', 'x-amz-sns-topic-arn': expectedTopicArn },
-      body: JSON.stringify({ paramsHash: 'mockParamsHash' }),
+      body: JSON.stringify({}),
     };
 
     const mockMsg = 'mockMsg';
@@ -108,7 +108,7 @@ describe('parseSNSMessage', () => {
     const mockReq = {
       params: { experimentId },
       headers: { authorization: 'mockAuthorization', 'x-amz-sns-topic-arn': expectedTopicArn },
-      body: JSON.stringify({ paramsHash: 'mockParamsHash' }),
+      body: JSON.stringify({}),
       app: { get: jest.fn(() => mockIo) },
     };
 


### PR DESCRIPTION
# Description
The `params_hash` column is not needed anymore.  This PR creates a migration to remove `params_hash` from the `experiment_execution` table.

Creating this to test PR https://github.com/biomage-org/iac/pull/135

# Details
#### URL to issue
https://biomage.atlassian.net/browse/BIOMAGE-2346

#### Link to staging deployment URL (or set N/A)
N/A https://ui-agi-api123.scp-staging.biomage.net/

#### Links to any PRs or resources related to this PR
N/A

#### Integration test branch
master

# Merge checklist
Your changes will be ready for merging after all of the steps below have been completed.

### Manual/unit testing
- [ ] Tested changes using InfraMock locally **or** no tests required for change, e.g. Kubernetes chart updates.
- [ ] Validated that current unit tests for code work as expected and are sufficient for code coverage **or** no unit tests required for change, e.g. documentation update.
- [ ] Unit tests written **or** no unit tests required for change, e.g. documentation update.

### Integration testing
**You must check the box below** to run integration tests on the latest commit on your PR branch.
Integration tests have to pass before the PR can be merged. Without checking the box, your PR
**will not pass** the required status checks for merging.

- [ ] Started end-to-end tests on the latest commit.

### Documentation updates
- [ ] Relevant Github READMEs updated **or** no GitHub README updates required.
- [ ] Relevant Wiki pages created/updated **or** no Wiki updates required.

### Optional
- [ ] Staging environment is unstaged before merging.
- [ ] Photo of a cute animal attached to this PR.